### PR TITLE
Update gemspec to include required ruby version

### DIFF
--- a/changeful.gemspec
+++ b/changeful.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |spec|
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
+  spec.required_ruby_version = '>= 2.0.0'
 
   spec.add_dependency "rails", "> 4.2.0"
 


### PR DESCRIPTION
Update Gemspec to include required ruby version for rubygem.org