### PR TITLE
Convert ActiveAdmin into generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,36 +21,35 @@ gem 'changeful'
 
 And then execute:
 
-```ruby
+```
 $ bundle install
 ```
 
 Or install it yourself as:
 
-```ruby
+```
 $ gem install changeful
 ```
 
 After you install Changeful to your Gemfile, you need to run the generator:
 
-```ruby
-rails generate changeful:install
+```
+$ rails generate changeful:install
 ```
 
 This will generate the migration needed for Changeful
 
 Run the migration to update the schema
 
-```ruby
-rake db:migrate
+```
+$ rake db:migrate
 ```
 
 ## Usage
 
 ### ERB
-```ruby
+```erb
 <h1><%= changeful_content(:about_us_title) %></h1>
-
 <div class='about-us-content'>
   <%= changeful_content :about_us_content do %>
     <p>You can also include HTML content as the default content in a block.</p>
@@ -60,7 +59,7 @@ rake db:migrate
 ```
 
 ### HAML
-```ruby
+```haml
 %h1= changeful_content(:about_us_title)
 .about-us-content
   = changeful_content :about_us_content do
@@ -69,9 +68,8 @@ rake db:migrate
 ```
 
 ### Slim
-```ruby
+```slim
 h1 = changeful_content(:about_us_title)
-
 .about-us-content
   = changeful_content :about_us_content do
     p You can also include HTML content as the default content in a block.
@@ -104,59 +102,17 @@ cc :about_us_title, default: 'About Us', type: :plain
 ## Integration with back-end
 
 ### ActiveAdmin
-Currently it only work well with ActiveAdmin
 
-Register the model with ActiveAdmin
+Run the following CLI to generate the model
 
-```ruby
-rails g active_admin:resource Changeful::Content
+```
+$ rails generate changeful:models:active_admin
 ``` 
 
-By default it will create `changeful_content.rb` in `app/admin` folder
+By default it will create `changeful_content.rb` in `app/admin` folder with the default configuration.
 
-#### Configuration for ActiveAdmin
+Note: The default configuration for text editor assumes you are using the `ckeditor` gem, replace the editor accordingly.
 
-Copy the setup below to `changeful_content.rb`
-
-Note: the example below is using `ckeditor` gem, replace the editor accordingly.
-
-```ruby
-ActiveAdmin.register Changeful::Content do
-  permit_params :content
-  actions :all, except: [:new]
-
-  index do
-    selectable_column
-    id_column
-    column :key, ->(row) { row.key.titleize  }
-    column :content
-    column :updated_at
-    actions
-  end
-
-  show do
-    attributes_table do
-      row :id
-      row :file_path
-      row :key
-      row :content
-      row :updated_at
-    end
-  end
-
-  form do |f|
-    f.inputs 'Details' do
-      input :key, input_html: { disabled: true  }
-      if f.object.view_type == 'html'
-        input :content, as: :ckeditor
-      else
-        input :content
-      end
-    end
-    actions
-  end
-end
-```
 ## Contributing
 
 1. Fork it ( https://github.com/futureworkz/changeful/fork   )

--- a/lib/generators/changeful/models/active_admin_generator.rb
+++ b/lib/generators/changeful/models/active_admin_generator.rb
@@ -1,0 +1,15 @@
+require 'rails/generators/base'
+
+module Changeful
+  module Generators
+    module Models
+      class ActiveAdminGenerator < Rails::Generators::Base # :nodoc:
+        source_root File.expand_path('../../templates', __FILE__)
+
+        def copy_changeful_active_admin_model_file
+          copy_file 'active_admin.rb', 'app/admin/changeful_content.rb'
+        end
+      end
+    end
+  end
+end

--- a/lib/generators/changeful/templates/active_admin.rb
+++ b/lib/generators/changeful/templates/active_admin.rb
@@ -1,0 +1,35 @@
+ActiveAdmin.register Changeful::Content, as: 'Contents' do
+  permit_params :content
+  actions :all, except: [:new, :destroy]
+
+  index do
+    selectable_column
+    id_column
+    column :key, ->(row) { row.key.titleize  }
+    column :content
+    column :updated_at
+    actions
+  end
+
+  show do
+    attributes_table do
+      row :id
+      row :file_path
+      row :key
+      row :content
+      row :updated_at
+    end
+  end
+
+  form do |f|
+    f.inputs 'Details' do
+      input :key, input_html: { disabled: true  }
+      if f.object.view_type == 'html'
+        input :content, as: :ckeditor
+      else
+        input :content
+      end
+    end
+    actions
+  end
+end

--- a/spec/changeful/generators/models/active_admin_generator_spec.rb
+++ b/spec/changeful/generators/models/active_admin_generator_spec.rb
@@ -1,0 +1,15 @@
+require 'generator_spec'
+require_relative '../../../../lib/generators/changeful/models/active_admin_generator'
+
+describe Changeful::Generators::Models::ActiveAdminGenerator, type: :generator do
+  destination File.expand_path('../../../../tmp', __FILE__)
+
+  before do
+    prepare_destination
+    run_generator
+  end
+
+  it 'create model file with activeadmin setting' do
+    assert_file 'app/admin/changeful_content.rb', /permit_params :content/
+  end
+end


### PR DESCRIPTION
Convert ActiveAdmin into generator, to be able to create the default configuration needed, in order to reduce the need of users to config manually.